### PR TITLE
Fix protected resource session ID handling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -174,13 +174,13 @@ async def log_keypress(
 @app.get("/protected_resource", response_model=ProtectedResourceResponse)
 async def get_protected_resource(
     request: Request,
-    session_id: str = None,
+    session_id: str | None = None,
     access_state: dict = Depends(get_user_access_state),
 ):
     """
     A protected resource, accessible only if the correct spell was cast by the session.
     """
-    if session_id is None:
+    if not session_id:
         logger.warning(
             f"Access attempt to /protected_resource without session_id from {request.client.host}"
         )

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -187,6 +187,13 @@ class TestProtectedResourceEndpoint:
         assert response.status_code == 401
         assert response.json()["detail"] == "Session ID required"
 
+    def test_protected_resource_empty_session_id(self, test_client):
+        """Test accessing protected resource with empty session_id."""
+        response = test_client.get("/protected_resource?session_id=")
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Session ID required"
+
     def test_protected_resource_invalid_session_id(self, test_client):
         """Test accessing protected resource with invalid session_id."""
         response = test_client.get("/protected_resource?session_id=invalid-uuid")


### PR DESCRIPTION
## Summary
- treat empty `session_id` the same as missing
- cover empty `session_id` case in endpoint tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685444af7094833287fb9bbdac06cfae