### PR TITLE
Enable DB persistence with PostgreSQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ wheels/
 .venv
 .aider*
 .env
+app.db

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,131 @@
+import os
+from datetime import datetime
+
+from sqlalchemy import (
+    create_engine,
+    MetaData,
+    Table,
+    Column,
+    String,
+    Boolean,
+    DateTime,
+    insert,
+    select,
+    update,
+)
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
+
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
+SessionLocal = sessionmaker(bind=engine)
+
+metadata = MetaData()
+
+user_access_table = Table(
+    "user_access",
+    metadata,
+    Column("uuid", String, primary_key=True),
+    Column("granted", Boolean, nullable=False, default=False),
+)
+
+successful_spell_ips_table = Table(
+    "successful_spell_ips",
+    metadata,
+    Column("ip", String, primary_key=True),
+    Column("user_uuid", String, nullable=False),
+    Column("cast_time", DateTime, nullable=False),
+)
+
+
+def init_db(engine_override=None):
+    """Create database tables."""
+    metadata.create_all(engine_override or engine)
+
+
+class UserAccessState:
+    """Dictionary-like access state persisted in the database."""
+
+    def __init__(self, engine=engine):
+        self.engine = engine
+        self.Session = sessionmaker(bind=engine)
+
+    def __setitem__(self, uuid: str, granted: bool):
+        with self.Session() as session:
+            exists = session.execute(
+                select(user_access_table.c.uuid).where(user_access_table.c.uuid == uuid)
+            ).scalar()
+            if exists is not None:
+                session.execute(
+                    update(user_access_table)
+                    .where(user_access_table.c.uuid == uuid)
+                    .values(granted=granted)
+                )
+            else:
+                session.execute(
+                    insert(user_access_table).values(uuid=uuid, granted=granted)
+                )
+            session.commit()
+
+    def get(self, uuid: str, default=None):
+        with self.Session() as session:
+            result = session.execute(
+                select(user_access_table.c.granted).where(
+                    user_access_table.c.uuid == uuid
+                )
+            ).scalar()
+            return default if result is None else result
+
+
+class SuccessfulSpellIPsState:
+    """Dictionary-like IP tracking persisted in the database."""
+
+    def __init__(self, engine=engine):
+        self.engine = engine
+        self.Session = sessionmaker(bind=engine)
+
+    def __contains__(self, ip: str) -> bool:
+        with self.Session() as session:
+            return (
+                session.execute(
+                    select(successful_spell_ips_table.c.ip).where(
+                        successful_spell_ips_table.c.ip == ip
+                    )
+                ).scalar()
+                is not None
+            )
+
+    def __setitem__(self, ip: str, value: dict):
+        with self.Session() as session:
+            exists = session.execute(
+                select(successful_spell_ips_table.c.ip).where(
+                    successful_spell_ips_table.c.ip == ip
+                )
+            ).scalar()
+            if exists is not None:
+                session.execute(
+                    update(successful_spell_ips_table)
+                    .where(successful_spell_ips_table.c.ip == ip)
+                    .values(user_uuid=value["user_uuid"], cast_time=value["cast_time"])
+                )
+            else:
+                session.execute(
+                    insert(successful_spell_ips_table).values(
+                        ip=ip, user_uuid=value["user_uuid"], cast_time=value["cast_time"]
+                    )
+                )
+            session.commit()
+
+    def get(self, ip: str, default=None):
+        with self.Session() as session:
+            row = session.execute(
+                select(
+                    successful_spell_ips_table.c.user_uuid,
+                    successful_spell_ips_table.c.cast_time,
+                ).where(successful_spell_ips_table.c.ip == ip)
+            ).first()
+            if row:
+                return {"user_uuid": row.user_uuid, "cast_time": row.cast_time}
+            return default
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: appuser
+      POSTGRES_PASSWORD: apppass
+      POSTGRES_DB: appdb
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+  api:
+    build: .
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: postgresql+psycopg2://appuser:apppass@db:5432/appdb
+    ports:
+      - "8000:8000"
+volumes:
+  postgres_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ fastapi==0.115.12
 uvicorn[standard]==0.34.3
 jinja2==3.1.6
 python-dotenv==1.1.0
+SQLAlchemy==2.0.30
+psycopg2-binary==2.9.9

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -250,10 +250,19 @@ class TestEnvironmentConfiguration:
         """Test behavior with empty spell configuration."""
         from main import app, get_key_buffer_manager, get_user_access_state
         from key_buffer_manager import KeyBufferManager
+        from app.database import metadata, UserAccessState
+        from sqlalchemy import create_engine
+        from sqlalchemy.pool import StaticPool
 
         # Create singleton instances for this test
         test_manager_instance = None
-        test_access_state_instance = {}
+        engine = create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        metadata.create_all(engine)
+        test_access_state_instance = UserAccessState(engine)
 
         # Override with empty spell
         def create_empty_spell_manager():

--- a/tests/integration/test_db_persistence.py
+++ b/tests/integration/test_db_persistence.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+from app.database import metadata, UserAccessState, SuccessfulSpellIPsState
+
+
+def test_user_access_persists():
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    metadata.create_all(engine)
+    access = UserAccessState(engine)
+    access["u1"] = True
+    assert access.get("u1") is True
+
+
+def test_successful_spell_ip_persists():
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    metadata.create_all(engine)
+    ips = SuccessfulSpellIPsState(engine)
+    now = datetime.utcnow()
+    ips["1.2.3.4"] = {"user_uuid": "u1", "cast_time": now}
+    assert "1.2.3.4" in ips
+    data = ips.get("1.2.3.4")
+    assert data["user_uuid"] == "u1"
+
+from fastapi.testclient import TestClient
+from app.key_buffer_manager import KeyBufferManager
+from main import (
+    app,
+    get_key_buffer_manager,
+    get_user_access_state,
+    get_successful_spell_ips_state,
+)
+
+
+def test_state_updated_after_spell(simple_spell):
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    metadata.create_all(engine)
+    manager = KeyBufferManager(parsed_secret_spell=simple_spell)
+    access_state = UserAccessState(engine)
+    ips_state = SuccessfulSpellIPsState(engine)
+    app.dependency_overrides[get_key_buffer_manager] = lambda: manager
+    app.dependency_overrides[get_user_access_state] = lambda: access_state
+    app.dependency_overrides[get_successful_spell_ips_state] = lambda: ips_state
+    client = TestClient(app)
+    uuid = "db-spell"
+    for key in simple_spell:
+        client.post("/keypress", json={"key": key, "uuid": uuid})
+
+    assert access_state.get(uuid) is True
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- add SQLAlchemy database layer for user access and spell tracking
- create docker-compose with Postgres service
- persist state through database-backed dependency classes
- update tests to use SQLite in-memory DB
- add dedicated persistence tests

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-test.txt`
- `pytest -k 'not ui' -q`

------
https://chatgpt.com/codex/tasks/task_e_68545ff1d78c833284ab706f52065a18