### PR TITLE
Add negative assertion in complete spell test

### DIFF
--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -39,6 +39,9 @@ class TestKeypressEndpoint:
             response = test_client_with_spell.post("/keypress", json=payload)
             responses.append(response.json())
 
+        # All but the last response should not trigger the spell
+        assert all(r["spell_successful"] is False for r in responses[:-1])
+
         # Last response should indicate spell success
         final_response = responses[-1]
         assert final_response["spell_successful"] is True


### PR DESCRIPTION
## Summary
- update integration test for complete spell sequence to assert partial responses aren't successful

## Testing
- `pip install -r requirements-test.txt`
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68559c9879a883328b24c5ee1dd7da42